### PR TITLE
Throw on empty component property name

### DIFF
--- a/lib/EntityManager.js
+++ b/lib/EntityManager.js
@@ -307,6 +307,10 @@ EntityManager.prototype._indexGroup = function (Components) {
  */
 function componentPropertyName (Component) {
   var name = getName(Component)
+  if (!name) {
+    throw new Error("Component property name is empty, " +
+                    "try naming your component function")
+  }
   return name.charAt(0).toLowerCase() + name.slice(1)
 }
 

--- a/test/entities-components.js
+++ b/test/entities-components.js
@@ -81,3 +81,20 @@ test('Throw in incorrect entity removal', function (t) {
     entities.removeEntity(e1)
   })
 })
+
+test('Throw on empty component property', function (t) {
+  t.plan(2)
+
+  var entities = nano()
+  var entity = entities.createEntity()
+
+  t.throws(function() {
+    entities.entityAddComponent(entity, function () {})
+  }, Error, 'anonymous function')
+
+  t.throws(function() {
+    var object = {}
+    object.method = function() {}
+    entities.entityAddComponent(entity, object.method)
+  }, Error, 'anonymous function as object method')
+})


### PR DESCRIPTION
Been using nano-ecs for a bit. Love how straight-forward it is.

This patch is inspired by attempting to put my components in a namespace, as object properties. It didn't really work, as typedef.getName returns empty on anonymous functions resulting in an empty component property name.

One option that I thought of was - well, just pass the component name to the addComponent method. A moment later a better option occurred to me - just name your anonymous function to pass the component name. So that's why this patch throws and suggests doing so in the error message.