### PR TITLE
Cache group keys to minimize allocation during queries

### DIFF
--- a/lib/EntityManager.js
+++ b/lib/EntityManager.js
@@ -41,6 +41,12 @@ function EntityManager () {
    * @private
    */
   this._componentPools = {}
+
+  /**
+   * Map of component groups to group keys.
+   * @private
+   */
+  this._groupKeyMap = new WeakMap()
 }
 
 /**
@@ -247,7 +253,7 @@ EntityManager.prototype.entityRemoveComponent = function (entity, Component) {
  * @return {Array.<Entity>}
  */
 EntityManager.prototype.queryComponents = function (Components) {
-  var group = this._groups[groupKey(Components)]
+  var group = this._groups[this._groupKey(Components)]
 
   if (!group) {
     group = this._indexGroup(Components)
@@ -284,7 +290,7 @@ EntityManager.prototype.count = function () {
  * @private
  */
 EntityManager.prototype._indexGroup = function (Components) {
-  var key = groupKey(Components)
+  var key = this._groupKey(Components)
 
   if (this._groups[key]) return
 
@@ -319,15 +325,24 @@ function componentPropertyName (Component) {
  * @return {String}
  * @private
  */
-function groupKey (Components) {
+EntityManager.prototype._groupKey = function (Components) {
+  var cachedKey = this._groupKeyMap.get(Components);
+  if (cachedKey) {
+    return cachedKey;
+  }
+
   var names = []
   for (var n = 0; n < Components.length; n++) {
     var T = Components[n]
     names.push(getName(T))
   }
 
-  return names
+  var key = names
     .map(function (x) { return x.toLowerCase() })
     .sort()
     .join('-')
+
+  this._groupKeyMap.set(Components, key);
+
+  return key;
 }

--- a/lib/EntityManager.js
+++ b/lib/EntityManager.js
@@ -326,9 +326,9 @@ function componentPropertyName (Component) {
  * @private
  */
 EntityManager.prototype._groupKey = function (Components) {
-  var cachedKey = this._groupKeyMap.get(Components);
+  var cachedKey = this._groupKeyMap.get(Components)
   if (cachedKey) {
-    return cachedKey;
+    return cachedKey
   }
 
   var names = []
@@ -342,7 +342,7 @@ EntityManager.prototype._groupKey = function (Components) {
     .sort()
     .join('-')
 
-  this._groupKeyMap.set(Components, key);
+  this._groupKeyMap.set(Components, key)
 
-  return key;
+  return key
 }


### PR DESCRIPTION
Basically, `groupKey` allocates some temporary objects via the .map, .sort and .join calls, and that's showing up on the Firefox profiler. It's not a big deal, but I made it go away with this patch. It uses a WeakMap to avoid a memory leak when `queryComponents` is passed a new array every time.