### PR TITLE
added fix to pass any number of args to component constructor

### DIFF
--- a/lib/EntityManager.js
+++ b/lib/EntityManager.js
@@ -167,7 +167,7 @@ EntityManager.prototype.entityRemoveTag = function (entity, tag) {
  * @param {Entity} entity
  * @param {Function} Component
  */
-EntityManager.prototype.entityAddComponent = function (entity, Component, args) {
+EntityManager.prototype.entityAddComponent = function (entity, Component, args = []) {
   if (~entity._Components.indexOf(Component)) return
 
   entity._Components.push(Component)
@@ -175,10 +175,7 @@ EntityManager.prototype.entityAddComponent = function (entity, Component, args) 
   // Create the reference on the entity to this component
   var cName = componentPropertyName(Component)
 
-  // HACK: how can you pass varargs to a constructor?
-  args = args || []
-  entity[cName] = new Component(entity, args[0], args[1], args[2], args[3],
-  args[4], args[5], args[6], args[7])
+  entity[cName] = new Component(entity, ...args)
 
   entity[cName].entity = entity
 

--- a/lib/EntityManager.js
+++ b/lib/EntityManager.js
@@ -167,7 +167,7 @@ EntityManager.prototype.entityRemoveTag = function (entity, tag) {
  * @param {Entity} entity
  * @param {Function} Component
  */
-EntityManager.prototype.entityAddComponent = function (entity, Component, args = []) {
+EntityManager.prototype.entityAddComponent = function (entity, Component, args) {
   if (~entity._Components.indexOf(Component)) return
 
   entity._Components.push(Component)
@@ -175,6 +175,7 @@ EntityManager.prototype.entityAddComponent = function (entity, Component, args =
   // Create the reference on the entity to this component
   var cName = componentPropertyName(Component)
 
+  args = args || []
   entity[cName] = new Component(entity, ...args)
 
   entity[cName].entity = entity


### PR DESCRIPTION
Made use of the [spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) to automatically expand component arguments to pass to the size of the array of args. Tested using the provided tests w/ tape.