### PR TITLE
add option to prevent component property names from being lower cased

### DIFF
--- a/lib/EntityManager.js
+++ b/lib/EntityManager.js
@@ -1,5 +1,5 @@
-module.exports = function () {
-  return new EntityManager()
+module.exports = function (options) {
+  return new EntityManager(options)
 }
 
 var Entity = require('./Entity.js')
@@ -11,7 +11,7 @@ var getName = require('typedef').getName
  * (tags, components) directly or via the facade on the Entity.
  * @constructor
  */
-function EntityManager () {
+function EntityManager (options = {}) {
   /**
    * Map of tags to the list of their entities.
    * @private
@@ -41,6 +41,15 @@ function EntityManager () {
    * @private
    */
   this._componentPools = {}
+
+  /**
+   * Provide options for backwards compatible support
+   * @type {{camelCase: boolean}}
+   * @private
+   */
+  this._options = Object.assign({}, {
+    camelCase: true
+  }, options)
 }
 
 /**
@@ -167,7 +176,7 @@ EntityManager.prototype.entityAddComponent = function (entity, Component) {
   entity._Components.push(Component)
 
   // Create the reference on the entity to this component
-  var cName = componentPropertyName(Component)
+  var cName = componentPropertyName(Component, this._options.camelCase)
   entity[cName] = new Component(entity)
 
   entity[cName].entity = entity
@@ -236,7 +245,7 @@ EntityManager.prototype.entityRemoveComponent = function (entity, Component) {
   }
 
   // Remove T listing on entity and property ref, then free the component.
-  var propName = componentPropertyName(Component)
+  var propName = componentPropertyName(Component, this._options.camelCase)
   entity._Components.splice(index, 1)
   delete entity[propName]
 }
@@ -302,14 +311,18 @@ EntityManager.prototype._indexGroup = function (Components) {
 
 /**
  * @param {Function} Component
+ * @param {Boolean} camelCase whether to change casing of the name
  * @return {String}
  * @private
  */
-function componentPropertyName (Component) {
+function componentPropertyName (Component, camelCase = true) {
   var name = getName(Component)
   if (!name) {
     throw new Error('Component property name is empty, ' +
                     'try naming your component function')
+  }
+  if (!camelCase) {
+    return name
   }
   return name.charAt(0).toLowerCase() + name.slice(1)
 }

--- a/lib/EntityManager.js
+++ b/lib/EntityManager.js
@@ -55,7 +55,7 @@ function EntityManager (options = {}) {
    */
   this._options = Object.assign({}, {
     camelCase: true
-  }, options)  
+  }, options)
 }
 
 /**

--- a/test/entities-components.js
+++ b/test/entities-components.js
@@ -98,3 +98,27 @@ test('Throw on empty component property', function (t) {
     entities.entityAddComponent(entity, object.method)
   }, Error, 'anonymous function as object method')
 })
+
+test('Added component has first character lower-cased by default', function (t) {
+  t.plan(1)
+
+  var entities = nano()
+  function C () { }
+
+  var entity = entities.createEntity()
+
+  entities.entityAddComponent(entity, C)
+  t.ok(entity.c instanceof C, 'added lower-cased')
+})
+
+test('Added component first character is not lower-cased when camelCase option is false', function (t) {
+  t.plan(1)
+
+  var entities = nano({camelCase: false})
+  function C () { }
+
+  var entity = entities.createEntity()
+
+  entities.entityAddComponent(entity, C)
+  t.ok(entity.C instanceof C, 'added w/out case change')
+})


### PR DESCRIPTION
By default when a component is added to an entity, the first letter of the component name is lower-cased. I find this to be difficult for a few reasons:
  * When you have components named as initialisms (Ie `STR`, `DEX`) it leads to odd casing when addressing the components on the entity (Ie `entity.sTR`, and `entity.dEX`).
  * There is an additive cognitive tax on the developer as they have to continually make casing decisions when adding features. For example, with serialization: mapping component names back to Component functions.  
  * Some editors w/ static analysis built-in can warn you about typos or undefined values. They are pretty good at guessing likely associations but get tripped up by the case change. The current behavior confuses those helpers. Below is a screenshot of the an editor being confused by `entity.sTR` but understands `entity.DEX`. 
<img width="437" alt="Screen Shot 2020-05-23 at 12 23 47 PM" src="https://user-images.githubusercontent.com/487411/82738955-9854cd80-9cf0-11ea-91b1-dca8221e173c.png">
  
This PR adds the functionality to let the developer disable the lower-casing of the first letter in the component property name. This functionality is opt-in to maintain backwards compatibility. 

If the developer prefers the old functionality of `entity.componentName`, no change is required.
If the developer would like to use `entity.ComponentName`, simply call nano with `camelCase:false` option: `let world = nano({camelCase: false});`.
